### PR TITLE
shifted dash_available around to be used in base movement component.

### DIFF
--- a/entities/chicken_player/player_movement_component.gd
+++ b/entities/chicken_player/player_movement_component.gd
@@ -11,6 +11,7 @@ extends BaseMovementComponent
 @export var dash_stamina_cost: int = 30
 @export var glide_stamina_cost: int = 20
 
+var dash_available: bool = true
 var jump_available: bool = true
 
 

--- a/entities/chicken_player/states/movement_states/dash_state.gd
+++ b/entities/chicken_player/states/movement_states/dash_state.gd
@@ -7,7 +7,7 @@ extends BasePlayerMovementState
 
 var _stamina_cost: int
 
-var _dash_available: bool = true
+
 var _is_dashing: bool = false
 var _dash_direction: Vector3
 
@@ -21,14 +21,14 @@ func enter(prev_state: BasePlayerMovementState, information: Dictionary = {}) ->
 	_stamina_cost = movement_component.dash_stamina_cost
 	
 	# Handle state transitions
-	if not _dash_available or player.stats.current_stamina < _stamina_cost:
-		print("Dash available: ", _dash_available)
+	if not movement_component.dash_available or player.stats.current_stamina < _stamina_cost:
+		print("Dash available: ", movement_component.dash_available)
 		SignalManager.player_transition_state.emit(previous_state.state_type, information)
 		return
 	
 	SignalManager.stamina_changed.emit(player.stats.drain_stamina(_stamina_cost))
 	
-	_dash_available = false
+	movement_component.dash_available = false
 	_is_dashing = true
 	
 	_dash_direction = get_player_direction()
@@ -76,5 +76,5 @@ func _on_dash_duration_timer_timeout():
 
 
 func _on_dash_cooldown_timer_timeout():
-	print("Dash available: ", _dash_available)
-	_dash_available = true
+	print("Dash available: ", movement_component.dash_available)
+	movement_component.dash_available = true

--- a/entities/chicken_player/states/movement_states/jump_state.gd
+++ b/entities/chicken_player/states/movement_states/jump_state.gd
@@ -19,7 +19,7 @@ func enter(prev_state: BasePlayerMovementState, information: Dictionary = {}) ->
 
 
 func input(_event: InputEvent) -> void:
-	if Input.is_action_just_pressed("dash"):
+	if Input.is_action_just_pressed("dash") && movement_component.dash_available:
 		SignalManager.player_transition_state.emit(PlayerEnums.PlayerStates.DASH_STATE, {})
 		return
 	


### PR DESCRIPTION
## Description

Shifted dash_available variable from dash state to base movement component. Changed conditions within dash state to use new variable and added check within jump state to use this variable.

##Related issue

Noticed a bug where you could cancel your jump with the dash key while dash was on cooldown.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I am merging into the correct branch.
- [ ] I have added appropriate documentation for the changes made.
- [x] I have followed the branch naming convention (`feature/hotfix/fix`), e.g., `feature/player_movement`.
