### PR TITLE
Fixed enemy hp not resetting and damage number

### DIFF
--- a/entities/enemies/woodpecker/woodpecker.tscn
+++ b/entities/enemies/woodpecker/woodpecker.tscn
@@ -4,8 +4,8 @@
 [ext_resource type="Resource" uid="uid://d2pw0mto5qqma" path="res://entities/enemies/woodpecker/woodpecker_stats.tres" id="3_woodpecker_stats"]
 [ext_resource type="BehaviorTree" uid="uid://dn83muanle5ic" path="res://entities/enemies/ai/trees/woodpecker.tres" id="4_1t2bg"]
 [ext_resource type="PackedScene" uid="uid://bcy114uphsh2s" path="res://entities/enemies/woodpecker/art/woodpecker.glb" id="4_woodpecker_model"]
-[ext_resource type="PackedScene" uid="uid://dldj0suybdnhl" path="res://entities/weapons/melee_weapons/melee_weapon_models/dagger/dagger.tscn" id="5_br0sw"]
 [ext_resource type="PackedScene" uid="uid://dsbwyfawptt0o" path="res://entities/weapons/melee_weapons/melee_weapon_handlers/melee_weapon.tscn" id="5_vfx5i"]
+[ext_resource type="PackedScene" uid="uid://bymaeu4dtl7ex" path="res://entities/weapons/melee_weapons/melee_weapon_models/leek/leek.tscn" id="6_vfx5i"]
 [ext_resource type="PackedScene" uid="uid://d4f8lcshn8fb4" path="res://entities/abilities/ability_slot.tscn" id="6_x6gfb"]
 [ext_resource type="Resource" uid="uid://cwwmblkt7dr02" path="res://entities/abilities/ability_models/fire_ball/fire_ball.tres" id="7_p6jwh"]
 [ext_resource type="Texture2D" uid="uid://bqvvdvkbjcu8y" path="res://entities/enemies/woodpecker/art/woodpecker_mugshot.png" id="8_p6jwh"]
@@ -31,7 +31,7 @@ bones/6/rotation = Quaternion(0.0921738, -2.5427e-08, -0.109848, 0.989665)
 bones/7/rotation = Quaternion(0.372215, 1.9392e-07, -0.443588, 0.815283)
 bones/8/rotation = Quaternion(-0.254674, -5.70863e-08, 0.303508, 0.918163)
 bones/9/rotation = Quaternion(-0.0929396, -1.66711e-08, 0.110761, 0.989492)
-bones/10/rotation = Quaternion(-0.0114476, 2.59861e-08, 0.0136427, 0.999841)
+bones/10/rotation = Quaternion(-0.0114476, 2.59773e-08, 0.0136427, 0.999842)
 bones/11/rotation = Quaternion(0.428146, 0.0317808, 0.888001, -0.164725)
 bones/12/rotation = Quaternion(-0.0928503, 0.0199919, -0.0528651, 0.994075)
 bones/14/position = Vector3(0.0982326, 2.09585, -1.47197)
@@ -51,7 +51,7 @@ behavior_tree = ExtResource("4_1t2bg")
 
 [node name="MeleeWeapon" parent="EnemyWeaponController" index="0" instance=ExtResource("5_vfx5i")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.751483, 1.60008, -0.692675)
-melee_weapon_scene = ExtResource("5_br0sw")
+melee_weapon_scene = ExtResource("6_vfx5i")
 weapon_collision_mask = 2
 
 [node name="AbilitySlot" parent="EnemyAbilityController" index="0" instance=ExtResource("6_x6gfb")]

--- a/entities/entity_stats/living_entity_stats.gd
+++ b/entities/entity_stats/living_entity_stats.gd
@@ -50,10 +50,8 @@ var current_stamina: float:
 func init() -> void:
 	if max_health <= 0: push_error("Max health must be positive.")
 	if max_stamina <= 0: push_error("Max stamina must be positive.")
-	if current_health == 0:
-		current_health = max_health
-	if current_stamina == 0:
-		current_stamina = max_stamina
+	current_health = max_health
+	current_stamina = max_stamina
 
 
 ## Calculate the speed based on weight and speed factor
@@ -116,9 +114,9 @@ func calc_scaled_damage(damage: float) -> float:
 		return INF
 	else:
 		actual_damage = floor(damage * (1.0 + (attack / 100)))
-	
+
 	print("Damage: " + str(damage) + " Attack: " + str(attack) + " Scaled Damage: " + str(actual_damage))
-	
+
 	return actual_damage
 
 

--- a/level/level.tscn
+++ b/level/level.tscn
@@ -68,7 +68,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 20)
 [node name="RoundHandler" type="Node" parent="."]
 script = ExtResource("9_cw150")
 enemy_scenes = Array[PackedScene]([ExtResource("11_rhqlf"), ExtResource("7_7jqyl"), ExtResource("6_fm1jd"), ExtResource("8_m5ivw"), ExtResource("9_fm1jd"), ExtResource("10_7jqyl")])
-waiting_time = 1.5
+waiting_time = 2.5
 
 [node name="NavigationRegion3D" type="NavigationRegion3D" parent="." groups=["NavRegion"]]
 navigation_mesh = SubResource("NavigationMesh_l5lfc")

--- a/level/round/round_handler.gd
+++ b/level/round/round_handler.gd
@@ -103,7 +103,7 @@ func _enter_in_progress() -> void:
 			_current_enemy = _pick_random_enemy(first_enemy_type)
 
 	_spawn_enemy_in_level()
-	
+
 	SaveManager.save_enemy_encounter(_current_enemy.stats.name)
 
 	await SignalManager.enemy_died
@@ -127,7 +127,6 @@ func _enter_concluding() -> void:
 		SignalManager.add_ui_scene.emit(UIEnums.UI.VICTORY_SCREEN, {"currency_dict": currency_overview_dict})
 		# Don't proceed further in this function if game is ending
 		return
-
 
 	# Display enemy defeated message and add currency
 	if _current_enemy == null:

--- a/ui/damage_number/damage_number_handler.gd
+++ b/ui/damage_number/damage_number_handler.gd
@@ -16,6 +16,8 @@ extends Marker3D
 
 
 func display_damage(value: int) -> void:
+	if value <= 0: return
+
 	var damage_number: DamageNumber = damage_number_resource.instantiate()
 
 	var spawn_position: Vector3 = global_position + Vector3(

--- a/ui/damage_number/damage_number_handler.gd
+++ b/ui/damage_number/damage_number_handler.gd
@@ -16,7 +16,7 @@ extends Marker3D
 
 
 func display_damage(value: int) -> void:
-	if value <= 0: return
+	if value == 0: return
 
 	var damage_number: DamageNumber = damage_number_resource.instantiate()
 

--- a/ui/damage_number/damage_number_handler.gd
+++ b/ui/damage_number/damage_number_handler.gd
@@ -29,7 +29,7 @@ func display_damage(value: int) -> void:
 	add_child(damage_number)
 
 	damage_number.global_position = spawn_position
-	damage_number.label.text = str(value)
+	damage_number.label.text = str(sign(value))
 	damage_number.label.font_size = base_size * randi_range(1, size_variation)
 	damage_number.label.modulate = damage_color if value >= 0 else heal_color
 


### PR DESCRIPTION
## Description

- Fixed enemy hp not resetting
- Changed damage number to not display if damage dealt is 0 or lower

## Related Issue

Resolves #277 