### PR TITLE
Fix fireball first hit instance not registering immediately after hit

### DIFF
--- a/entities/abilities/ability_models/fire_ball/fire_ball.gd
+++ b/entities/abilities/ability_models/fire_ball/fire_ball.gd
@@ -2,13 +2,13 @@ extends Ability
 
 @export var travel_speed: float = 5.0 # Speed at which the fireball moves forward
 @export var lifetime: float = 6.0 # Duration before the fireball expires
-@export var damage_interval: float = 0.2
+@export var damage_interval: float = 0.4
 @export_range(1, 2, 0.01) var scale_factor: float = 1.75
 
-var stamina_drain: float
 var damage: float:
 	get:
-		return stamina_drain
+		var stats: LivingEntityStats = ability_holder.stats
+		return ((stats.current_stamina / stats.max_stamina) * 100) / 2
 
 var _is_active: bool = false
 var _travel_direction: Vector3
@@ -16,7 +16,6 @@ var _current_damage: float = 0.0
 var _remaining_lifetime: float = 0.0
 var _active_bodies: Dictionary[int, int] = {}
 
-@onready var stats: LivingEntityStats 
 @onready var hit_area: Area3D = %HitArea
 @onready var mesh_instance: MeshInstance3D = %MeshInstance3D
 @onready var collision_shape: CollisionShape3D = %CollisionShape3D
@@ -24,16 +23,15 @@ var _active_bodies: Dictionary[int, int] = {}
 
 
 func activate() -> void:
-	stats = ability_holder.stats
 	# Ignore the parent's transform
 	# This ensures the fireball moves independently, without being affected by the player's movement
 	top_level = true
 	global_position = ability_holder.global_position + (Vector3.UP * 2) # Move Y up by 2, so it spawns a bit centered
-	stamina_drain = ((stats.current_stamina / stats.max_stamina) * 100) / 2
-	stats.current_stamina -= stamina_drain
-	
+
+	ability_holder.stats.current_stamina -= damage
+
 	_toggle_collision_masks(true, hit_area)
-	
+
 	_is_active = true
 	_travel_direction = -ability_holder.global_basis.z.normalized()
 	_current_damage = damage
@@ -67,7 +65,7 @@ func _physics_process(delta: float) -> void:
 	# Increase the current damage depending on remaining lifetime and the speed it travels at
 	# As the remaining lifetime decreases, the damage will ramp up
 	_current_damage += damage * ((1.0 + (_remaining_lifetime / lifetime)) * delta) / (travel_speed * 2)
-	
+
 	mesh_instance.scale = scale_increment
 	collision_shape.scale = scale_increment
 	cpu_particles.scale = scale_increment
@@ -83,6 +81,8 @@ func _on_hit_area_body_entered(body: Node3D) -> void:
 		var id: int = body.get_instance_id()
 		if not _active_bodies.has(id):
 			_active_bodies[id] = Time.get_ticks_msec()
+
+			_apply_damage(body)
 
 
 func _on_hit_area_body_exited(body: Node3D) -> void:
@@ -106,8 +106,12 @@ func _apply_continuous_damage() -> void:
 			_active_bodies[id] = current_time
 
 			# Only apply damage if body is Player of Enemy
-			if body.collision_layer == 2 or body.collision_layer == 4:
-				SignalManager.weapon_hit_target.emit(body, _current_damage, DamageEnums.DamageTypes.NORMAL)
+			_apply_damage(body)
+
+
+func _apply_damage(body: CharacterBody3D) -> void:
+	if body.collision_layer == 2 or body.collision_layer == 4:
+		SignalManager.weapon_hit_target.emit(body, _current_damage, DamageEnums.DamageTypes.NORMAL)
 
 
 func _reset_ability() -> void:

--- a/entities/abilities/ability_models/fire_ball/fire_ball.tres
+++ b/entities/abilities/ability_models/fire_ball/fire_ball.tres
@@ -11,7 +11,7 @@ purchasable = true
 drop_chance = 20
 cost = 150
 currency_type = 0
-description = "The user launches a fiery projectile straight ahead, dealing damage to targets in its path. The fireball travels at [color=\"yellow\"]5 m/s[/color] for up to [color=\"yellow\"]6 seconds[/color], growing in size and intensity—the longer it remains on the arena, the more powerful its damage becomes. Targets caught within the fireball take damage every [color=\"yellow\"]0.2 seconds[/color]. This ability has a cooldown of %s."
+description = "The user launches a fiery projectile straight ahead, dealing damage to targets in its path. The fireball travels at [color=\"yellow\"]5 m/s[/color] for up to [color=\"yellow\"]6 seconds[/color], growing in size and intensity—the longer it remains on the arena, the more powerful its damage becomes. Targets caught within the fireball take damage immediately, then every [color=\"yellow\"]0.4 seconds[/color] afterward. This ability has a cooldown of %s."
 icon = ExtResource("1_aief6")
 model_uid = "uid://r2kfankkht6"
 metadata/_custom_type_script = "uid://cqht6vad2p0dc"

--- a/entities/abilities/ability_models/fire_ball/fire_ball.tscn
+++ b/entities/abilities/ability_models/fire_ball/fire_ball.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=14 format=3 uid="uid://r2kfankkht6"]
 
-[ext_resource type="PackedScene" uid="uid://ewtev0tsouye" path="res://entities/abilities/ability.tscn" id="1_l7j4w"]
+[ext_resource type="PackedScene" uid="uid://bon7ywv24hl73" path="res://entities/abilities/ability.tscn" id="1_l7j4w"]
 [ext_resource type="Script" uid="uid://5b8scwscjndl" path="res://entities/abilities/ability_models/fire_ball/fire_ball.gd" id="2_ksrmm"]
 [ext_resource type="Resource" uid="uid://cwwmblkt7dr02" path="res://entities/abilities/ability_models/fire_ball/fire_ball.tres" id="3_fmore"]
 [ext_resource type="Shader" uid="uid://dlxoddwv36plh" path="res://entities/abilities/ability_models/fire_ball/fire_ball.gdshader" id="4_58kgr"]


### PR DESCRIPTION
## Description

- Updated description to reflect change in damage taken on hit and every 0.4s inside fire ball
- Fixed first hit instance of fire ball not registering on target hit (you could escape the fireball in that 0.4s timeframe before and not take damage, despite clearly entering its radius)
