### PR TITLE
Fix seas of flame initial damage

### DIFF
--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
@@ -7,7 +7,7 @@ extends Ability
 ## The interval between each instance of damage applied
 @export var damage_interval: float = 0.2
 ## The maximum damage multiplier applied at the start of the burn effect
-@export var peak_burn_modifier: float = 350
+@export var peak_burn_modifier: float = 175
 
 var damage: float:
 	get:

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
@@ -72,7 +72,7 @@ func _apply_burn(body: Node3D) -> void:
 
 			# Gradually decreasing the burn damage from peak to default across the damage tick count
 			var weight: float = i as float / (burn_tick_count - 1)
-			var burn_damage: float = lerp((peak_burn_modifier / 100.0), 1.0, weight) * (damage / burn_tick_count)
+			var burn_damage: float = lerp(peak_burn_modifier / 100.0, 1.0, weight) * (damage / burn_tick_count)
 
 			if body.collision_layer == 2: # Player
 				SignalManager.weapon_hit_target.emit(body, burn_damage, DamageEnums.DamageTypes.NORMAL)

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
@@ -6,8 +6,8 @@ extends Ability
 @export var damage_duration: float = 2.0
 ## The interval between each instance of damage applied
 @export var damage_interval: float = 0.2
-## The maximum damage multiplier applied at the start of the burn effect, gradually decreasing with each damage instance
-@export var peak_burn_modifier: float = 3.5
+## The maximum damage multiplier applied at the start of the burn effect
+@export var peak_burn_modifier: float = 350
 
 var damage: float:
 	get:
@@ -70,9 +70,10 @@ func _apply_burn(body: Node3D) -> void:
 			if not is_instance_valid(body):
 				break
 
+			# Gradually decreasing the burn damage from peak to default across the damage tick count
 			var weight: float = i as float / (burn_tick_count - 1)
-			var burn_damage: float = lerp(peak_burn_modifier, 1.0, weight) * (damage / burn_tick_count)
-		
+			var burn_damage: float = lerp((peak_burn_modifier / 100.0), 1.0, weight) * (damage / burn_tick_count)
+
 			if body.collision_layer == 2: # Player
 				SignalManager.weapon_hit_target.emit(body, burn_damage, DamageEnums.DamageTypes.NORMAL)
 			if body.collision_layer == 4: # Enemy

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.gd
@@ -7,7 +7,7 @@ extends Ability
 ## The interval between each instance of damage applied
 @export var damage_interval: float = 0.2
 ## The maximum damage multiplier applied at the start of the burn effect
-@export var peak_burn_modifier: float = 175
+@export var peak_burn_modifier: int = 175
 
 var damage: float:
 	get:

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tres
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tres
@@ -11,7 +11,7 @@ purchasable = true
 drop_chance = 15
 cost = 150
 currency_type = 0
-description = "The user sets the seas ablaze, sacrificing [color=yellow]20%%[/color] of Max Health to unleash an AoE attack within a [color=yellow]20 meter[/color] radius. Targets caught in the flames are afflicted with [color=red]Burn[/color], taking damage every [color=yellow]0.2 seconds[/color] for [color=yellow]2 seconds[/color]. The damage scales based on the user's Max Health, starting at a peak multiplier of [color=yellow]350%%[/color] and gradually decreases to its original value over time. Can only be used while on the ground and has a cooldown of %s."
+description = "The user sets the seas ablaze, sacrificing [color=yellow]20%%[/color] of Max Health to unleash an AoE attack within a [color=yellow]20 meter[/color] radius. Targets caught in the flames are afflicted with [color=red]Burn[/color], taking damage every [color=yellow]0.2 seconds[/color] for [color=yellow]2 seconds[/color]. The damage scales based on the user's Max Health, starting at a peak multiplier of [color=yellow]175%%[/color] and gradually decreases to its original value over time. Can only be used while on the ground and has a cooldown of %s."
 icon = ExtResource("1_ihale")
 model_uid = "uid://df1clah7xvv32"
 metadata/_custom_type_script = "uid://cqht6vad2p0dc"

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tres
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tres
@@ -11,7 +11,7 @@ purchasable = true
 drop_chance = 15
 cost = 150
 currency_type = 0
-description = "The user sets the seas ablaze, sacrificing [color=yellow]25%%[/color] of Max Health to unleash an AoE attack within a [color=yellow]25 meter[/color] radius. Targets caught in the flames are inflicted with Burn, taking damage over time. Can only be used while on the ground and has a cooldown of %s."
+description = "The user sets the seas ablaze, sacrificing [color=yellow]20%%[/color] of Max Health to unleash an AoE attack within a [color=yellow]20 meter[/color] radius. Targets caught in the flames are afflicted with [color=red]Burn[/color], taking damage over [color=yellow]2 seconds[/color], with damage ticks every [color=yellow]0.2 seconds[/color]. The damage starts at a peak multiplier of [color=yellow]350%[/color] and gradually decreases to it's original value over the duration. Can only be used while on the ground and has a cooldown of %s."
 icon = ExtResource("1_ihale")
 model_uid = "uid://df1clah7xvv32"
 metadata/_custom_type_script = "uid://cqht6vad2p0dc"

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tres
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tres
@@ -11,7 +11,7 @@ purchasable = true
 drop_chance = 15
 cost = 150
 currency_type = 0
-description = "The user sets the seas ablaze, sacrificing [color=yellow]20%%[/color] of Max Health to unleash an AoE attack within a [color=yellow]20 meter[/color] radius. Targets caught in the flames are afflicted with [color=red]Burn[/color], taking damage over [color=yellow]2 seconds[/color], with damage ticks every [color=yellow]0.2 seconds[/color]. The damage starts at a peak multiplier of [color=yellow]350%[/color] and gradually decreases to it's original value over the duration. Can only be used while on the ground and has a cooldown of %s."
+description = "The user sets the seas ablaze, sacrificing [color=yellow]20%%[/color] of Max Health to unleash an AoE attack within a [color=yellow]20 meter[/color] radius. Targets caught in the flames are afflicted with [color=red]Burn[/color], taking damage every [color=yellow]0.2 seconds[/color] for [color=yellow]2 seconds[/color]. The damage scales based on the user's Max Health, starting at a peak multiplier of [color=yellow]350%%[/color] and gradually decreases to its original value over time. Can only be used while on the ground and has a cooldown of %s."
 icon = ExtResource("1_ihale")
 model_uid = "uid://df1clah7xvv32"
 metadata/_custom_type_script = "uid://cqht6vad2p0dc"

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tscn
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tscn
@@ -37,7 +37,7 @@ script = ExtResource("2_7fey8")
 health_consumption = 20
 damage_duration = 2.0
 damage_interval = 0.2
-peak_burn_modifier = 350.0
+peak_burn_modifier = 175.0
 current_ability = ExtResource("3_nqrm3")
 
 [node name="HitArea" type="Area3D" parent="." index="1"]

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tscn
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tscn
@@ -37,7 +37,7 @@ script = ExtResource("2_7fey8")
 health_consumption = 20
 damage_duration = 2.0
 damage_interval = 0.2
-peak_burn_modifier = 3.5
+peak_burn_modifier = 350.0
 current_ability = ExtResource("3_nqrm3")
 
 [node name="HitArea" type="Area3D" parent="." index="1"]

--- a/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tscn
+++ b/entities/abilities/ability_models/seas_of_flame/seas_of_flame.tscn
@@ -6,7 +6,7 @@
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_gdliy"]
 height = 3.0
-radius = 25.0
+radius = 20.0
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_3lj7w"]
 transparency = 1
@@ -32,11 +32,12 @@ point_count = 3
 offsets = PackedFloat32Array(0.170792, 0.529703, 0.943069)
 colors = PackedColorArray(0.447771, 0.19073, 0.221989, 1, 0.649454, 0.194277, 0.285676, 1, 0.701369, 0.336546, 0.2301, 1)
 
-[node name="SeaOfFlame" instance=ExtResource("1_vfv0y")]
+[node name="SeasOfFlame" instance=ExtResource("1_vfv0y")]
 script = ExtResource("2_7fey8")
-health_consumption = 25.0
+health_consumption = 20
 damage_duration = 2.0
-damage_interval = 0.4
+damage_interval = 0.2
+peak_burn_modifier = 3.5
 current_ability = ExtResource("3_nqrm3")
 
 [node name="HitArea" type="Area3D" parent="." index="1"]
@@ -50,7 +51,6 @@ shape = SubResource("CylinderShape3D_gdliy")
 
 [node name="CPUParticles3D" type="CPUParticles3D" parent="HitArea" index="1"]
 unique_name_in_owner = true
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
 emitting = false
 amount = 750
 one_shot = true
@@ -63,7 +63,7 @@ emission_shape = 6
 emission_ring_axis = Vector3(0, 1, 0)
 emission_ring_height = 3.0
 emission_ring_radius = 0.5
-emission_ring_inner_radius = 25.0
+emission_ring_inner_radius = 20.0
 emission_ring_cone_angle = 90.0
 direction = Vector3(0, 1, 0)
 spread = 0.0


### PR DESCRIPTION
## Description

- Updated the damage of seas of flame to include a PEAK modifier
  - included `current_health` in the initial damage, so the first activation actually does damage instead of just 1
- Adjusted the description to reflect the change

## Related Issue

Resolves #282 

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I am merging into the correct branch.
- [ ] I have added appropriate documentation for the changes made.
- [x] I have followed the branch naming convention (`feature/hotfix/fix`), e.g., `feature/player_movement`.